### PR TITLE
Add dummy LangGraph agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ai-agents",
+  "version": "1.0.0",
+  "description": "A simple, modular AI agent framework built on top of LangGraph.js.",
+  "type": "module",
+  "scripts": {
+    "test": "node tests/dummyAgent.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/src/dummyAgent.js
+++ b/src/dummyAgent.js
@@ -1,0 +1,31 @@
+// Dummy agent built with LangGraph.js
+// This example demonstrates how to wire a simple one-node graph
+// that returns a static greeting. It requires the `@langchain/langgraph`
+// package, which may need to be installed separately.
+
+import { StateGraph, END } from '@langchain/langgraph';
+
+// Define a minimal graph with a single node.
+const workflow = new StateGraph({
+  channels: {
+    text: {
+      // Simple passthrough channel that accepts and outputs strings
+      value: (x) => x
+    }
+  }
+});
+
+// Add a single node that always returns a greeting.
+workflow.addNode('start', async (state) => ({ text: 'Hello from dummy agent!' }));
+
+// Mark the end of the graph.
+workflow.addEdge('start', END);
+
+// Compile the graph into an executable app.
+export const app = workflow.compile();
+
+// Convenience helper to run the agent.
+export async function runDummyAgent(input = {}) {
+  const result = await app.invoke({ text: input.text ?? '' });
+  return result.text;
+}

--- a/tests/dummyAgent.test.js
+++ b/tests/dummyAgent.test.js
@@ -1,0 +1,8 @@
+import assert from 'assert';
+import { runDummyAgent } from '../src/dummyAgent.js';
+
+(async () => {
+  const output = await runDummyAgent();
+  assert.strictEqual(output, 'Hello from dummy agent!');
+  console.log('dummy agent test passed');
+})();


### PR DESCRIPTION
## Summary
- scaffold Node.js project and add package configuration
- create dummy agent using LangGraph.js
- add basic test harness for agent

## Testing
- `npm test` *(fails: Cannot find package '@langchain/langgraph')*


------
https://chatgpt.com/codex/tasks/task_e_6891cf96f250832d99ea217f6be7f68c