### PR TITLE
Integrate context7 MCP stub into dummy agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ai-agents",
+  "version": "1.0.0",
+  "description": "A simple, modular AI agent framework built on top of LangGraph.js.",
+  "type": "module",
+  "scripts": {
+    "test": "node tests/dummyAgent.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/src/context7Mcp.js
+++ b/src/context7Mcp.js
@@ -1,0 +1,8 @@
+// Simple stub for the Context7 MCP loader
+export function loadContext7MCP() {
+  return {
+    name: 'context7',
+    version: 'mcp-1.0',
+    getContext: () => 'stub context'
+  };
+}

--- a/src/dummyAgent.js
+++ b/src/dummyAgent.js
@@ -1,0 +1,32 @@
+// Dummy agent built with a lightweight LangGraph stub and Context7 MCP
+// integration. This demonstrates wiring a simple one-node graph that
+// returns a static greeting while also loading the Context7 MCP client.
+
+import { StateGraph, END } from './langgraphStub.js';
+import { loadContext7MCP } from './context7Mcp.js';
+
+// Define a minimal graph with a single node.
+const workflow = new StateGraph({
+  channels: {
+    text: {
+      // Simple passthrough channel that accepts and outputs strings
+      value: (x) => x
+    }
+  }
+});
+
+// Add a single node that always returns a greeting.
+workflow.addNode('start', async (state) => ({ text: 'Hello from dummy agent!' }));
+
+// Mark the end of the graph.
+workflow.addEdge('start', END);
+
+// Compile the graph into an executable app.
+export const app = workflow.compile();
+
+// Convenience helper to run the agent.
+export async function runDummyAgent(input = {}) {
+  const ctx = loadContext7MCP();
+  const result = await app.invoke({ text: input.text ?? '' });
+  return `${result.text} Using ${ctx.name} MCP.`;
+}

--- a/src/langgraphStub.js
+++ b/src/langgraphStub.js
@@ -1,0 +1,18 @@
+export class StateGraph {
+  constructor() {
+    this.node = null;
+  }
+  addNode(name, fn) {
+    this.node = fn;
+  }
+  addEdge() {
+    // no-op for stub
+  }
+  compile() {
+    const fn = this.node;
+    return {
+      invoke: async (state) => fn(state)
+    };
+  }
+}
+export const END = Symbol('END');

--- a/tests/dummyAgent.test.js
+++ b/tests/dummyAgent.test.js
@@ -1,0 +1,8 @@
+import assert from 'assert';
+import { runDummyAgent } from '../src/dummyAgent.js';
+
+(async () => {
+  const output = await runDummyAgent();
+  assert.strictEqual(output, 'Hello from dummy agent! Using context7 MCP.');
+  console.log('dummy agent test passed');
+})();


### PR DESCRIPTION
## Summary
- implement lightweight stubs for LangGraph and a Context7 MCP loader
- update dummy agent to load Context7 MCP and use LangGraph stub
- adjust test to confirm Context7 MCP integration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891cf96f250832d99ea217f6be7f68c